### PR TITLE
Add health check service with AWS Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 ## Unreleased
+
+### New Features
+- Add health check service with caching and AWS integration.
+
 ### Dependency Versions
 - **Sentry:** 5.8.0
-- **AWS SDK:** 2.31.77
-- **JUnit Jupiter:** 5.13.3
-- **JUnit Platform:** 1.13.3
-- **Jackson:** 2.19.1
-- **Jandex:** 3.3.2
+- **AWS SDK:** 2.32.9
+- **JUnit Jupiter:** 6.0.0-M2
+- **JUnit Platform:** 6.0.0-M2
+- **Jackson:** 2.19.2
+- **Jandex:** 3.4.0
+- **Log4j:** 2.25.1
+- **Caffeine:** 3.2.2
 
 ## Version 1.1.0
 **Release Date:** 2025-06-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## Unreleased
 ### Dependency Versions
 - **Sentry:** 5.8.0
-- **AWS SDK:** 2.31.74
-- **JUnit Jupiter:** 5.13.2
-- **JUnit Platform:** 1.13.2
+- **AWS SDK:** 2.31.77
+- **JUnit Jupiter:** 5.13.3
+- **JUnit Platform:** 1.13.3
 - **Jackson:** 2.19.1
+- **Jandex:** 3.3.2
 
 ## Version 1.1.0
 **Release Date:** 2025-06-20

--- a/README.md
+++ b/README.md
@@ -97,3 +97,13 @@ If the instances match the specified filters, the response will resemble the exa
 ```
 
 If the request contains invalid parameters, the service responds with HTTP status 400, including an alarms section detailing the validation issues.
+
+
+## Health Check Service
+
+This service provides a simple endpoint to check the health status of the application.  
+The endpoint returns a 200 Ok response with the message "Services working" if all internal health checks pass, or a 503 Service Unavailable response with the message "Health check failed" if any check fails.
+
+```http
+GET /healthcheck
+```

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,8 @@ dependencies {
     implementation("io.smallrye:jandex:3.3.1")
     implementation("org.glassfish.jaxb:jaxb-runtime:4.0.5")
 
+    implementation("com.github.ben-manes.caffeine:caffeine:3.2.1")
+
     testImplementation("org.junit.jupiter:junit-jupiter-api:${jUnitJupiterVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jUnitJupiterVersion}")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:${jUnitPlatformVersion}")

--- a/build.gradle
+++ b/build.gradle
@@ -16,13 +16,13 @@ repositories {
 }
 
 ext {
-    awsVersion = '2.31.77'
-    jUnitJupiterVersion = '5.13.3'
-    jUnitPlatformVersion = '1.13.3'
+    awsVersion = '2.32.9'
+    jUnitJupiterVersion = '6.0.0-M2'
+    jUnitPlatformVersion = '6.0.0-M2'
     lombokVersion = '1.18.38'
-    jacksonVersion = '2.19.1'
+    jacksonVersion = '2.19.2'
     jerseyVersion = '4.0.0-M2'
-    log4jVersion = '2.25.0'
+    log4jVersion = '2.25.1'
 }
 
 java {
@@ -60,10 +60,10 @@ dependencies {
     compileOnly('jakarta.ws.rs:jakarta.ws.rs-api:4.0.0')
     compileOnly('jakarta.servlet:jakarta.servlet-api:6.1.0')
 
-    implementation("io.smallrye:jandex:3.3.2")
+    implementation("io.smallrye:jandex:3.4.0")
     implementation("org.glassfish.jaxb:jaxb-runtime:4.0.5")
 
-    implementation("com.github.ben-manes.caffeine:caffeine:3.2.1")
+    implementation("com.github.ben-manes.caffeine:caffeine:3.2.2")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:${jUnitJupiterVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jUnitJupiterVersion}")

--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,9 @@ repositories {
 }
 
 ext {
-    awsVersion = '2.31.74'
-    jUnitJupiterVersion = '5.13.2'
-    jUnitPlatformVersion = '1.13.2'
+    awsVersion = '2.31.77'
+    jUnitJupiterVersion = '5.13.3'
+    jUnitPlatformVersion = '1.13.3'
     lombokVersion = '1.18.38'
     jacksonVersion = '2.19.1'
     jerseyVersion = '4.0.0-M2'
@@ -60,7 +60,7 @@ dependencies {
     compileOnly('jakarta.ws.rs:jakarta.ws.rs-api:4.0.0')
     compileOnly('jakarta.servlet:jakarta.servlet-api:6.1.0')
 
-    implementation("io.smallrye:jandex:3.3.1")
+    implementation("io.smallrye:jandex:3.3.2")
     implementation("org.glassfish.jaxb:jaxb-runtime:4.0.5")
 
     implementation("com.github.ben-manes.caffeine:caffeine:3.2.1")

--- a/src/main/java/com/aws/service/controller/HealthCheckController.java
+++ b/src/main/java/com/aws/service/controller/HealthCheckController.java
@@ -1,0 +1,28 @@
+package com.aws.service.controller;
+
+import com.aws.service.service.HealthCheckService;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/healthcheck")
+public class HealthCheckController {
+
+    private final HealthCheckService healthCheckService = new HealthCheckService();
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response health() {
+        boolean healthy = healthCheckService.checkHealthCached();
+
+        if (healthy) {
+            return Response.ok("Services working").build();
+        } else {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity("Health check failed")
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/aws/service/controller/HealthCheckController.java
+++ b/src/main/java/com/aws/service/controller/HealthCheckController.java
@@ -10,7 +10,11 @@ import jakarta.ws.rs.core.Response;
 @Path("/healthcheck")
 public class HealthCheckController {
 
-    private final HealthCheckService healthCheckService = new HealthCheckService();
+    private final HealthCheckService healthCheckService;
+
+    public HealthCheckController() {
+        this.healthCheckService = new HealthCheckService();
+    }
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)

--- a/src/main/java/com/aws/service/service/HealthCheckService.java
+++ b/src/main/java/com/aws/service/service/HealthCheckService.java
@@ -1,0 +1,75 @@
+package com.aws.service.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.sentry.Sentry;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest;
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
+import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetHealthRequest;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.DescribeTargetHealthResponse;
+
+public class HealthCheckService {
+
+    private final Cache<String, Boolean> healthCache;
+    private static final Logger logger = LoggerFactory.getLogger(HealthCheckService.class);
+
+    // spotless:off
+    public HealthCheckService() {
+        healthCache = Caffeine.newBuilder().expireAfterWrite(30, TimeUnit.SECONDS).build();
+    }
+    //spotless:on
+
+    /**
+     * Checks the cached health status of AWS services.
+     * @return true if both EC2 and ELB health checks pass, false otherwise.
+     */
+    public boolean checkHealthCached() {
+        return Boolean.TRUE.equals(healthCache.get("aws-health", key -> checkEc2() && checkElb()));
+    }
+
+    /**
+     * Checks the health of the EC2 service by attempting to describe instances.
+     * @return true if the EC2 service is accessible and returns a valid response.
+     */
+    public boolean checkEc2() {
+        try (Ec2Client ec2 = Ec2Client.create()) {
+            DescribeInstancesResponse response = ec2.describeInstances(
+                    DescribeInstancesRequest.builder().maxResults(5).build());
+            return response.reservations() != null;
+
+        } catch (Exception e) {
+            Sentry.captureException(e);
+            logger.error("EC2 check failed: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Verifies the status of the Elastic Load Balancer (ELB) by checking the health of its target group.
+     * @return true if the ELB's target group health details are successfully retrieved.
+     */
+    public boolean checkElb() {
+        String targetGroupArn = System.getenv("TARGET_GROUP_ARN");
+        if (targetGroupArn == null || targetGroupArn.isBlank()) {
+            logger.warn("ELB check skipped: no TARGET_GROUP_ARN set");
+            return true;
+        }
+
+        try (ElasticLoadBalancingV2Client elb = ElasticLoadBalancingV2Client.create()) {
+            DescribeTargetHealthResponse response = elb.describeTargetHealth(DescribeTargetHealthRequest.builder()
+                    .targetGroupArn(targetGroupArn)
+                    .build());
+            return response.targetHealthDescriptions() != null;
+
+        } catch (Exception e) {
+            Sentry.captureException(e);
+            logger.error("ELB check failed: {}", e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/aws/service/service/HealthCheckService.java
+++ b/src/main/java/com/aws/service/service/HealthCheckService.java
@@ -24,6 +24,10 @@ public class HealthCheckService {
     }
     //spotless:on
 
+    public HealthCheckService(Cache<String, Boolean> cache) {
+        this.healthCache = cache;
+    }
+
     /**
      * Checks the cached health status of AWS services.
      * @return true if both EC2 and ELB health checks pass, false otherwise.
@@ -40,7 +44,12 @@ public class HealthCheckService {
         try (Ec2Client ec2 = Ec2Client.create()) {
             DescribeInstancesResponse response = ec2.describeInstances(
                     DescribeInstancesRequest.builder().maxResults(5).build());
-            return response.reservations() != null;
+
+            if (response.reservations() == null || response.reservations().isEmpty()) {
+                logger.error("EC2 check failed: no reservations found");
+                return false;
+            }
+            return true;
 
         } catch (Exception e) {
             Sentry.captureException(e);

--- a/src/test/java/Ec2InstanceTest.java
+++ b/src/test/java/Ec2InstanceTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.WireMockServer;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -15,22 +14,20 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import server.WireMockHelper;
 
 public class Ec2InstanceTest {
 
-    private static final int WIREMOCK_PORT = 8080;
-    private static final String BASE_URL = "http://localhost:" + WIREMOCK_PORT + "/aws/ec2/instances";
+    private static final String BASE_URL = "http://localhost:" + WireMockHelper.getPort() + "/aws/ec2/instances";
     private static final String CONTENT_TYPE = "application/json";
 
-    private WireMockServer wireMockServer;
     private HttpClient client;
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-        wireMockServer = new WireMockServer(WIREMOCK_PORT);
-        wireMockServer.start();
-        configureFor("localhost", WIREMOCK_PORT);
+        WireMockHelper.startServer();
+        WireMockHelper.reset();
 
         client = HttpClient.newHttpClient();
         objectMapper = new ObjectMapper();
@@ -38,7 +35,7 @@ public class Ec2InstanceTest {
 
     @AfterEach
     void tearDown() {
-        wireMockServer.stop();
+        WireMockHelper.stopServer();
     }
 
     /**

--- a/src/test/java/HealthCheckTest.java
+++ b/src/test/java/HealthCheckTest.java
@@ -1,0 +1,60 @@
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.aws.service.service.HealthCheckService;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import server.WireMockHelper;
+
+public class HealthCheckTest {
+
+    private HealthCheckService service;
+
+    @BeforeEach
+    void setup() {
+        WireMockHelper.startServer();
+        WireMockHelper.reset();
+
+        System.setProperty("aws.region", "eu-central-1");
+        System.setProperty("AWS_ACCESS_KEY_ID", "test");
+        System.setProperty("AWS_SECRET_ACCESS_KEY", "test");
+        System.setProperty("TARGET_GROUP_ARN", "arn:aws:elasticloadbalancing:123456789");
+
+        String endpoint = "http://localhost:" + WireMockHelper.getPort();
+        System.setProperty("software.amazon.awssdk.ec2.endpoint", endpoint);
+        System.setProperty("software.amazon.awssdk.elasticloadbalancingv2.endpoint", endpoint);
+
+        Cache<String, Boolean> noCache = Caffeine.newBuilder().maximumSize(0).build();
+        service = new HealthCheckService(noCache);
+    }
+
+    @AfterEach
+    void tearDown() {
+        WireMockHelper.stopServer();
+    }
+
+    @Test
+    void shouldReturnFalseWhenEc2Fails() {
+        stubFor(post(urlPathEqualTo("/"))
+                .withRequestBody(containing("DescribeInstances"))
+                .willReturn(serverError()));
+
+        stubFor(
+                post(urlPathEqualTo("/"))
+                        .withRequestBody(containing("DescribeTargetHealth"))
+                        .willReturn(
+                                okXml(
+                                        """
+                            <DescribeTargetHealthResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
+                                <TargetHealthDescriptions/>
+                            </DescribeTargetHealthResponse>
+                        """)));
+
+        boolean result = service.checkHealthCached();
+
+        assertFalse(result, "Health check should fail if EC2 fails");
+    }
+}

--- a/src/test/java/LoadBalancerStatusTest.java
+++ b/src/test/java/LoadBalancerStatusTest.java
@@ -3,7 +3,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.WireMockServer;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -13,22 +12,21 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import server.WireMockHelper;
 
 public class LoadBalancerStatusTest {
 
-    private static final int WIREMOCK_PORT = 8080;
-    private static final String BASE_URL = "http://localhost:" + WIREMOCK_PORT + "/aws/load-balancer/service/status";
+    private static final String BASE_URL =
+            "http://localhost:" + WireMockHelper.getPort() + "/aws/load-balancer/service/status";
     private static final String CONTENT_TYPE = "application/json";
 
-    private WireMockServer wireMockServer;
     private HttpClient client;
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-        wireMockServer = new WireMockServer(WIREMOCK_PORT);
-        wireMockServer.start();
-        configureFor("localhost", WIREMOCK_PORT);
+        WireMockHelper.startServer();
+        WireMockHelper.reset();
 
         client = HttpClient.newHttpClient();
         objectMapper = new ObjectMapper();
@@ -36,7 +34,7 @@ public class LoadBalancerStatusTest {
 
     @AfterEach
     void tearDown() {
-        wireMockServer.stop();
+        WireMockHelper.stopServer();
     }
 
     /**

--- a/src/test/java/server/WireMockHelper.java
+++ b/src/test/java/server/WireMockHelper.java
@@ -1,0 +1,49 @@
+package server;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+public class WireMockHelper {
+
+    private static final int PORT = 8080;
+    private static WireMockServer wireMockServer;
+
+    /**
+     * Starts the WireMock server to enable mocking of HTTP requests and responses.
+     */
+    public static void startServer() {
+        if (wireMockServer == null) {
+            wireMockServer = new WireMockServer(PORT);
+            wireMockServer.start();
+            configureFor("localhost", PORT);
+        }
+    }
+
+    /**
+     * Stops the WireMock server if it is currently running.
+     */
+    public static void stopServer() {
+        if (wireMockServer != null && wireMockServer.isRunning()) {
+            wireMockServer.stop();
+            wireMockServer = null;
+        }
+    }
+
+    /**
+     * Retrieves the port number on which the WireMock server is configured to run.
+     * @return the port number used by the WireMock server
+     */
+    public static int getPort() {
+        return PORT;
+    }
+
+    /**
+     * Resets the state of the WireMock server by removing all mappings, requests, and scenarios.
+     */
+    public static void reset() {
+        if (wireMockServer != null) {
+            wireMockServer.resetAll();
+        }
+    }
+}


### PR DESCRIPTION
Add Health Check Service with AWS Integration, Caching, and Test Improvements
This PR introduces a /healthcheck endpoint backed by a new HealthCheckService that checks EC2 and ELB status, with Caffeine-based caching for performance.
- 🛠️ Integrated AWS EC2 and ELB health checks
- ⚡ Added Caffeine caching and updated build.gradle
- 🧪 Refactored tests using WireMockHelper + added HealthCheckTest
- 📚 Updated README.md with endpoint usage
- ⬆️ Upgraded AWS SDK, JUnit, Jackson, Log4j, and more